### PR TITLE
Use homegrown self assessment

### DIFF
--- a/responses/welcome.md
+++ b/responses/welcome.md
@@ -6,7 +6,7 @@ Throughout the course, you'll be prompted to have offline conversations with dep
 
 ## Complete the self assessment
 
-As we begin our journey into preparing for open source, let's start with a few self assessment of where your open source program stands today.
+As we begin our journey into preparing for open source, let's start with a few self assessments of where your open source program stands today.
 1. Navigate to the [open source self assessments](https://githubtraining.github.io/oss-assessment/).
 1. Take each of the assessments.
 1. Jot down your level within each dimension.


### PR DESCRIPTION
Transferring the assessment from Survey Gizmo to Survey Monkey ended up being pretty painful. When we finally got around to getting it to work, Survey Monkey wasn't displaying just the feedback, but it looked like a quiz with "right" and "wrong" answers, and very little control over that interface.

So I created a very basic assessment with some html/css/javascript. I hope over time we can iterate on this, but I think it'll do the trick for now. 

The assessments themselves are in [their own repo](https://github.com/githubtraining/oss-assessment) and served with GitHub Pages. We don't store any data.

Closes #2 
Closes #12 
Closes #13 