### PR TITLE
Rename master to main in all instructions and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ For more information on the goals of this course, check out the [`course-details
 
 ## Contribute
 
-See something we could improve? Check out the contributing guide in the [community contributors repository](https://github.com/githubtraining/community-contributors/blob/master/CONTRIBUTING.md) for more information on the types of contributions we :heart: and instructions.
+See something we could improve? Check out the contributing guide in the [community contributors repository](https://github.com/githubtraining/community-contributors/blob/main/CONTRIBUTING.md) for more information on the types of contributions we :heart: and instructions.
 
-We :heart: our community and take great care to ensure it is fun, safe and rewarding. Please review our [Code of Conduct](https://github.com/githubtraining/community-contributors/blob/master/CODE_OF_CONDUCT.md) for community expectations and guidelines for reporting concerns.
+We :heart: our community and take great care to ensure it is fun, safe and rewarding. Please review our [Code of Conduct](https://github.com/githubtraining/community-contributors/blob/main/CODE_OF_CONDUCT.md) for community expectations and guidelines for reporting concerns.
 
 ## License
 

--- a/config.yml
+++ b/config.yml
@@ -327,7 +327,7 @@ steps:
     action_id: finalIssue
     data:
       forkURL: '%payload.repository.html_url%/fork'
-      downloadURL: '%payload.repository.html_url%/archive/master.zip'
+      downloadURL: '%payload.repository.html_url%/archive/main.zip'
   - type: respond
     with: goto-final-issue.md
     data:


### PR DESCRIPTION
This pull request changes references to the `master` branch to the `main` branch.

Once this is ready to merge, I will:

- [x] Rename the default branch in this repository
- [x] Update any other PRs in this repository
- [x] Rename the default branch in the [template repository](https://github.com/githubtraining/open-source-kit)
- [ ] Merge this PR
- [x] Test to make sure things work as expected

cc @githubtraining/programs